### PR TITLE
Add GitHub issue templates for repository maintenance

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,23 @@
+name: Bug report
+description: Report broken links, markdown issues, or code sample problems
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What is wrong?
+      placeholder: Broken link, wrong code snippet, invalid build config, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: location
+    attributes:
+      label: Affected location
+      description: Which file or section is affected?
+      placeholder: README.md, docs/JUC.md, pom.xml, etc.
+    validations:
+      required: true
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Chinese home
+    url: https://github.com/loulanyue/java-multithreading/blob/master/README.md
+    about: Review the main navigation page before opening broad content issues.

--- a/.github/ISSUE_TEMPLATE/content_request.yml
+++ b/.github/ISSUE_TEMPLATE/content_request.yml
@@ -1,0 +1,21 @@
+name: Content request
+description: Suggest a missing concurrency topic, interview guide, or code example
+title: "[Content]: "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: topic
+    attributes:
+      label: Requested topic
+      description: What should be added or expanded?
+      placeholder: e.g. AQS, CompletableFuture best practices, thread pool sizing, deadlock troubleshooting
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why it matters
+      description: Explain the review or interview value
+      placeholder: This topic appears often in Java backend interviews and deserves a focused note
+


### PR DESCRIPTION
## Summary
Add bug/content request issue forms and configure issue intake defaults.

## Why
This gives the repository a cleaner path for reporting broken links, incorrect examples, and missing topics.