### PR TITLE
Enable Dependabot for Actions and Maven

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary
Enable weekly Dependabot updates for GitHub Actions and Maven dependencies.

## Why
This makes the repository easier to maintain over time.