### PR TITLE
Add a multithreading interview checklist

### DIFF
--- a/docs/Multithreading Interview Checklist.md
+++ b/docs/Multithreading Interview Checklist.md
@@ -1,0 +1,43 @@
+# Multithreading Interview Checklist
+
+这份清单适合在面试前快速自查，确认自己是否已经掌握 Java 多线程中最常被追问的主线问题。
+
+## 基础主线
+
+- 能否清楚解释线程生命周期
+- 能否区分并发与并行
+- 能否说明 `start()` 和 `run()` 的区别
+- 能否解释 `wait()`、`notify()`、`sleep()` 的差异
+
+## 线程安全
+
+- 能否解释什么是竞态条件
+- 能否说清 `synchronized` 的作用和局限
+- 能否说明 `volatile` 解决了什么、没解决什么
+- 能否举例说明原子性、可见性、有序性
+
+## 锁与并发工具
+
+- 能否比较 `synchronized` 和 `Lock`
+- 能否讲清 `ReentrantLock`、`ReadWriteLock` 的适用场景
+- 能否解释 `CountDownLatch`、`CyclicBarrier`、`Semaphore`
+- 能否说明 CAS 和乐观锁的基本思路
+
+## 线程池
+
+- 能否说清线程池为什么重要
+- 能否解释核心参数：核心线程数、最大线程数、阻塞队列、拒绝策略
+- 能否说明为什么不建议直接使用 `Executors` 默认工厂
+
+## 高频专题
+
+- `BlockingQueue` 的常见实现和使用场景
+- `Callable` / `FutureTask` 和 `Runnable` 的区别
+- `CompletableFuture` 的基本链式调用思路
+- `ForkJoin` 的适用场景
+
+## 口述建议
+
+- 每个问题尽量按“定义 -> 作用 -> 典型场景 -> 注意点”回答
+- 如果能结合项目或线上问题说明，会比纯概念更有说服力
+- 回答锁和线程池时，优先强调取舍而不是只背 API

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,17 +9,19 @@ The detailed content is still primarily written in Chinese, but the structure be
 ## Recommended order
 
 1. [Multithreading Basics.md](Multithreading%20Basics.md)
-2. [JUC.md](JUC.md)
-3. [BlockingQueue.md](BlockingQueue.md)
-4. [Callable FutureTask.md](Callable%20FutureTask.md)
-5. [ForkJoin.md](ForkJoin.md)
-6. [batchRedis.md](batchRedis.md)
+2. [Multithreading Interview Checklist.md](Multithreading%20Interview%20Checklist.md)
+3. [JUC.md](JUC.md)
+4. [BlockingQueue.md](BlockingQueue.md)
+5. [Callable FutureTask.md](Callable%20FutureTask.md)
+6. [ForkJoin.md](ForkJoin.md)
+7. [batchRedis.md](batchRedis.md)
 
 ## Topic map
 
 | File | Topic | Description |
 | --- | --- | --- |
 | [Multithreading Basics.md](Multithreading%20Basics.md) | Multithreading basics | Core overview of lifecycle, locks, thread pools, and JUC tools |
+| [Multithreading Interview Checklist.md](Multithreading%20Interview%20Checklist.md) | Interview checklist | A practical self-check list for high-frequency Java concurrency questions |
 | [JUC.md](JUC.md) | JUC overview | Process vs thread, thread states, `wait` vs `sleep`, concurrency vs parallelism |
 | [BlockingQueue.md](BlockingQueue.md) | BlockingQueue | Blocking queue concepts, implementations, API styles, and example usage |
 | [Callable FutureTask.md](Callable%20FutureTask.md) | Callable and FutureTask | Ways to create concurrent tasks, return values, blocking result retrieval |


### PR DESCRIPTION
## Summary
Add a focused Java multithreading interview checklist and link it from the docs index.

## Why
This turns the repository into a more actionable interview-preparation resource, not just a note archive.